### PR TITLE
Update setup.py to be able to be able to upload the package to pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     version="2021.1.1",
     description="Python module to interact with VivintSky API.",
     long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
     author="Ovidiu Stateina, Nathan Spencer",
     author_email="ovidiurs@gmail.com",
     license="MIT",


### PR DESCRIPTION
### Problem
Currently we get an error when trying to upload the package to pypi because`setuptools.setup` method requires a new argument: `long_description_content_type`
```
> python3 -m twine upload dist/* --verbose                                                                                    ✔  10017  03:03:38
Using configuration from /home/[user]/.pypirc
Uploading distributions to https://upload.pypi.org/legacy/
  dist/pyvivint-2021.1.1-py3-none-any.whl (20.1 KB)
  dist/pyvivint-2021.1.1.tar.gz (14.9 KB)
Enter your username: [REMOVED]
Enter your password: 
username: [REMOVED]
password: <hidden>
Uploading pyvivint-2021.1.1-py3-none-any.whl
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 24.8k/24.8k [00:00<00:00, 45.7kB/s]
Content received from server:
<html>
 <head>
  <title>400 The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.</title>
 </head>
 <body>
  <h1>400 The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.</h1>
  The server could not comply with the request since it is either malformed or otherwise incorrect.<br/><br/>
The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.


 </body>
</html>
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.

```
### Solution
Set the long description content type to `text/markdown` by passing the `long_description_content_type` argument