### PR TITLE
Fix datetime format issue on camera thumbnail date

### DIFF
--- a/pyvivint/devices/camera.py
+++ b/pyvivint/devices/camera.py
@@ -86,8 +86,11 @@ class Camera(VivintDevice):
 
     async def get_thumbnail_url(self) -> str:
         """Returns the latest camera thumbnail URL."""
+        # Sometimes this date field comes back with a "Z" at the end
+        # and sometimes it doesn't, so let's just safely remove it.
         camera_thumbnail_date = datetime.strptime(
-            self.data[Attributes.CAMERA_THUMBNAIL_DATE], "%Y-%m-%dT%H:%M:%S.%f"
+            self.data[Attributes.CAMERA_THUMBNAIL_DATE].replace("Z", ""),
+            "%Y-%m-%dT%H:%M:%S.%f",
         )
         thumbnail_timestamp = int(camera_thumbnail_date.timestamp() * 1000)
 

--- a/pyvivint/devices/camera.py
+++ b/pyvivint/devices/camera.py
@@ -87,7 +87,7 @@ class Camera(VivintDevice):
     async def get_thumbnail_url(self) -> str:
         """Returns the latest camera thumbnail URL."""
         camera_thumbnail_date = datetime.strptime(
-            self.data[Attributes.CAMERA_THUMBNAIL_DATE], "%Y-%m-%dT%H:%M:%S.%fZ"
+            self.data[Attributes.CAMERA_THUMBNAIL_DATE], "%Y-%m-%dT%H:%M:%S.%f"
         )
         thumbnail_timestamp = int(camera_thumbnail_date.timestamp() * 1000)
 


### PR DESCRIPTION
Most of the time, the camera thumbnail date (ctd) field doesn't include a "Z" at the end. On rare instances, however, it shows up. This just strips it off if it exists to successfully handle both scenarios.