### PR TITLE
Patch pubnub reconnect logic

### DIFF
--- a/pyvivint/constants.py
+++ b/pyvivint/constants.py
@@ -26,22 +26,33 @@ class AuthUserAttribute(Constant):
     RELAY_SERVER = "rs"
     USERS = "u"
 
-    class UserAttribute(Constant):
-        """User Attributes"""
 
-        DOCUMENT_SEQUENCE = "DocumentSequence"
-        EMAIL = "e"
-        GHOME = "ghome"
-        GROUP_IDS = "grpid"
-        ID = "_id"
-        MESSAGE_BROADCAST_CHANNEL = "mbc"
-        NAME = "n"
-        PING_ID = "pngid"
-        RESTRICTED_SYSTEM = "rsystem"
-        SMART_HOME_SYSTEM = "smarthomesystem"
-        SETTINGS = "stg"
-        SYSTEM = "system"
-        TIMESTAMP = "ts"
+class UserAttribute(Constant):
+    """User attributes."""
+
+    DOCUMENT_SEQUENCE = "DocumentSequence"
+    EMAIL = "e"
+    GHOME = "ghome"
+    GROUP_IDS = "grpid"
+    ID = "_id"
+    MESSAGE_BROADCAST_CHANNEL = "mbc"
+    NAME = "n"
+    PING_ID = "pngid"
+    RESTRICTED_SYSTEM = "rsystem"
+    SMART_HOME_SYSTEM = "smarthomesystem"
+    SETTINGS = "stg"
+    SYSTEM = "system"
+    TIMESTAMP = "ts"
+
+
+class SystemAttribute(Constant):
+    """System attributes."""
+
+    PANEL_ID = "panid"
+    PARTITION = "par"
+    PARTITION_ID = "parid"
+    SYSTEM = "system"
+    SYSTEM_NICKNAME = "sn"
 
 
 class PubNubMessageAttribute(Constant):

--- a/pyvivint/pubnub.py
+++ b/pyvivint/pubnub.py
@@ -8,6 +8,8 @@ import pubnub.pubnub
 import pubnub.pubnub_asyncio
 from pubnub.callbacks import SubscribeCallback
 
+from . import pubnub_patches
+
 PN_SUBSCRIBE_KEY = "sub-c-6fb03d68-6a78-11e2-ae8f-12313f022c90"
 PN_CHANNEL = "PlatformChannel"
 

--- a/pyvivint/pubnub_patches.py
+++ b/pyvivint/pubnub_patches.py
@@ -1,0 +1,277 @@
+"""File for various patches to Pubnub until fixed in module."""
+
+import asyncio
+from asyncio import Event
+
+from aiohttp.client_exceptions import ClientConnectorError
+
+import pubnub
+from pubnub import utils
+from pubnub.endpoints.presence.heartbeat import Heartbeat
+from pubnub.endpoints.pubsub.subscribe import Subscribe
+from pubnub.enums import (
+    PNHeartbeatNotificationOptions,
+    PNOperationType,
+    PNReconnectionPolicy,
+    PNStatusCategory,
+)
+from pubnub.errors import (
+    PNERR_CLIENT_TIMEOUT,
+    PNERR_CONNECTION_ERROR,
+    PNERR_REQUEST_CANCELLED,
+)
+from pubnub.exceptions import PubNubException
+from pubnub.pubnub_asyncio import PubNubAsyncioException, logger
+
+
+async def patched_request_future(self, options_func, cancellation_event):
+    """
+    Patched `request_future` function on pubnub's `PubNubAsyncio` class.
+
+    Return status of PNStatusCategory.PNNetworkIssuesCategory when ClientConnectorError occurs.
+
+    See https://github.com/pubnub/python/pull/101 for when this can be removed.
+    """
+    try:
+        res = await self._request_helper(options_func, cancellation_event)
+        return res
+    except PubNubException as e:
+        return PubNubAsyncioException(result=None, status=e.status)
+    except asyncio.TimeoutError:
+        return PubNubAsyncioException(
+            result=None,
+            status=options_func().create_status(
+                PNStatusCategory.PNTimeoutCategory,
+                None,
+                None,
+                exception=PubNubException(pn_error=PNERR_CLIENT_TIMEOUT),
+            ),
+        )
+    except asyncio.CancelledError:
+        return PubNubAsyncioException(
+            result=None,
+            status=options_func().create_status(
+                PNStatusCategory.PNCancelledCategory,
+                None,
+                None,
+                exception=PubNubException(pn_error=PNERR_REQUEST_CANCELLED),
+            ),
+        )
+    except ClientConnectorError:
+        return PubNubAsyncioException(
+            result=None,
+            status=options_func().create_status(
+                PNStatusCategory.PNNetworkIssuesCategory,
+                None,
+                None,
+                exception=PubNubException(pn_error=PNERR_CONNECTION_ERROR),
+            ),
+        )
+    except Exception as e:
+        return PubNubAsyncioException(
+            result=None,
+            status=options_func().create_status(
+                PNStatusCategory.PNUnknownCategory, None, None, e
+            ),
+        )
+
+
+pubnub.pubnub_asyncio.PubNubAsyncio.request_future = patched_request_future
+
+
+async def patched_register_heartbeat_timer(self):
+    """
+    Patched `_register_heartbeat_timer` function on pubnub's `AsyncioReconnectionManager` class.
+
+    Raise exception when there is an error on heartbeat call so that reconnect logic actually happens.
+
+    See https://github.com/pubnub/python/pull/101 for when this can be removed.
+    """
+    while True:
+        self._recalculate_interval()
+
+        await asyncio.sleep(self._timer_interval)
+
+        logger.debug("reconnect loop at: %s" % utils.datetime_now())
+
+        try:
+            result = await self._pubnub.time().future()
+            if result.status.is_error():
+                raise result.status.error_data.exception
+            self._connection_errors = 1
+            self._callback.on_reconnect()
+            break
+        except Exception:
+            if self._pubnub.config.reconnect_policy == PNReconnectionPolicy.EXPONENTIAL:
+                logger.debug(
+                    "reconnect interval increment at: %s" % utils.datetime_now()
+                )
+                self._connection_errors += 1
+
+
+pubnub.pubnub_asyncio.AsyncioReconnectionManager._register_heartbeat_timer = (
+    patched_register_heartbeat_timer
+)
+
+
+async def patched_start_subscribe_loop(self):
+    """
+    Patched `_start_subscribe_loop` function on pubnub's `AsyncioSubscriptionManager` class.
+
+    Correctly call `_start_subscribe_loop` on timeouts.
+
+    See https://github.com/pubnub/python/pull/101 for when this can be removed.
+    """
+    self._stop_subscribe_loop()
+
+    await self._subscription_lock.acquire()
+
+    combined_channels = self._subscription_state.prepare_channel_list(True)
+    combined_groups = self._subscription_state.prepare_channel_group_list(True)
+
+    if len(combined_channels) == 0 and len(combined_groups) == 0:
+        self._subscription_lock.release()
+        return
+
+    self._subscribe_request_task = asyncio.ensure_future(
+        Subscribe(self._pubnub)
+        .channels(combined_channels)
+        .channel_groups(combined_groups)
+        .timetoken(self._timetoken)
+        .region(self._region)
+        .filter_expression(self._pubnub.config.filter_expression)
+        .future()
+    )
+
+    e = await self._subscribe_request_task
+
+    if self._subscribe_request_task.cancelled():
+        self._subscription_lock.release()
+        return
+
+    if e.is_error():
+        if (
+            e.status is not None
+            and e.status.category == PNStatusCategory.PNCancelledCategory
+        ):
+            self._subscription_lock.release()
+            return
+
+        if (
+            e.status is not None
+            and e.status.category == PNStatusCategory.PNTimeoutCategory
+        ):
+            asyncio.create_task(self._start_subscribe_loop())
+            self._subscription_lock.release()
+            return
+
+        logger.error("Exception in subscribe loop: %s" % str(e))
+
+        if (
+            e.status is not None
+            and e.status.category == PNStatusCategory.PNAccessDeniedCategory
+        ):
+            e.status.operation = PNOperationType.PNUnsubscribeOperation
+
+        # TODO: raise error
+        self._listener_manager.announce_status(e.status)
+
+        self._reconnection_manager.start_polling()
+        self._subscription_lock.release()
+        self.disconnect()
+        return
+    else:
+        self._handle_endpoint_call(e.result, e.status)
+        self._subscription_lock.release()
+        self._subscribe_loop_task = asyncio.ensure_future(self._start_subscribe_loop())
+
+    self._subscription_lock.release()
+
+
+pubnub.pubnub_asyncio.AsyncioSubscriptionManager._start_subscribe_loop = (
+    patched_start_subscribe_loop
+)
+
+
+async def patched_perform_heartbeat_loop(self):
+    """
+    Patched `_perform_heartbeat_loop` function on pubnub's `AsyncioSubscriptionManager` class.
+
+    Correctly adheres to setting for heartbeat_notification_options.
+    Call `_start_subscribe_loop` on timeouts and network issues.
+
+    See https://github.com/pubnub/python/pull/101 for when this can be removed.
+    """
+    if self._heartbeat_call is not None:
+        # TODO: cancel call
+        pass
+
+    cancellation_event = Event()
+    state_payload = self._subscription_state.state_payload()
+    presence_channels = self._subscription_state.prepare_channel_list(False)
+    presence_groups = self._subscription_state.prepare_channel_group_list(False)
+
+    if len(presence_channels) == 0 and len(presence_groups) == 0:
+        return
+
+    try:
+        heartbeat_call = (
+            Heartbeat(self._pubnub)
+            .channels(presence_channels)
+            .channel_groups(presence_groups)
+            .state(state_payload)
+            .cancellation_event(cancellation_event)
+            .future()
+        )
+
+        envelope = await heartbeat_call
+
+        heartbeat_verbosity = self._pubnub.config.heartbeat_notification_options
+        if heartbeat_verbosity == PNHeartbeatNotificationOptions.ALL or (
+            envelope.status.is_error()
+            and heartbeat_verbosity == PNHeartbeatNotificationOptions.FAILURES
+        ):
+            self._listener_manager.announce_status(envelope.status)
+
+        if envelope.status is not None and envelope.status.category in [
+            PNStatusCategory.PNTimeoutCategory,
+            PNStatusCategory.PNNetworkIssuesCategory,
+        ]:
+            await self._start_subscribe_loop()
+
+    except PubNubAsyncioException:
+        pass
+
+    finally:
+        cancellation_event.set()
+
+
+pubnub.pubnub_asyncio.AsyncioSubscriptionManager._perform_heartbeat_loop = (
+    patched_perform_heartbeat_loop
+)
+
+
+old_endpoint_name_for_operation = (
+    pubnub.pubnub.TelemetryManager.endpoint_name_for_operation
+)
+
+
+@staticmethod
+def patched_endpoint_name_for_operation(operation_type):
+    """
+    Patched `endpoint_name_for_operation` function on pubnub's `TelemetryManager` class.
+
+    Avoids KeyError(6) when operation_type == PNOperationType.PNHeartbeatOperation.
+
+    See https://github.com/pubnub/python/pull/100 for when this can be removed.
+    """
+    return (
+        "hb"
+        if operation_type == PNOperationType.PNHeartbeatOperation
+        else old_endpoint_name_for_operation(operation_type)
+    )
+
+
+pubnub.pubnub.TelemetryManager.endpoint_name_for_operation = (
+    patched_endpoint_name_for_operation
+)

--- a/pyvivint/system.py
+++ b/pyvivint/system.py
@@ -4,6 +4,7 @@ from typing import List
 
 import pyvivint.devices.alarm_panel
 from pyvivint.constants import PubNubMessageAttribute as MessageAttributes
+from pyvivint.constants import SystemAttribute
 from pyvivint.entity import Entity
 from pyvivint.utils import first_or_none
 from pyvivint.vivintskyapi import VivintSkyApi
@@ -20,13 +21,15 @@ class System(Entity):
         self.vivintskyapi = vivintskyapi
         self.alarm_panels: List[pyvivint.devices.alarm_panel.AlarmPanel] = [
             pyvivint.devices.alarm_panel.AlarmPanel(panel_data, self)
-            for panel_data in self.data["system"]["par"]
+            for panel_data in self.data[SystemAttribute.SYSTEM][
+                SystemAttribute.PARTITION
+            ]
         ]
 
     @property
     def id(self) -> str:
         """System's id"""
-        return self.data["system"]["panid"]
+        return self.data[SystemAttribute.SYSTEM][SystemAttribute.PANEL_ID]
 
     @property
     def name(self) -> str:
@@ -37,11 +40,13 @@ class System(Entity):
         """Reloads system's data from VivintSky API."""
         system_data = await self.vivintskyapi.get_system_data(self.id)
 
-        for panel_data in system_data["system"]["par"]:
+        for panel_data in system_data[SystemAttribute.SYSTEM][
+            SystemAttribute.PARTITION
+        ]:
             alarm_panel = first_or_none(
                 self.alarm_panels,
-                lambda panel: panel.id == panel_data["panid"]
-                and panel.partition_id == panel_data["parid"],
+                lambda panel: panel.id == panel_data[SystemAttribute.PANEL_ID]
+                and panel.partition_id == panel_data[SystemAttribute.PARTITION_ID],
             )
             if alarm_panel:
                 alarm_panel.refresh(panel_data)

--- a/pyvivint/vivint.py
+++ b/pyvivint/vivint.py
@@ -1,21 +1,25 @@
 """Module that implements the Vivint class."""
 import asyncio
-import json
 import logging
 from typing import List, Optional
 
 import aiohttp
+from aiohttp.client_exceptions import ClientConnectionError
 
 import pubnub
 import pyvivint.system
 from pubnub.enums import PNHeartbeatNotificationOptions, PNReconnectionPolicy
 from pubnub.pnconfiguration import PNConfiguration
 from pubnub.pubnub_asyncio import PubNubAsyncio
-from pyvivint.constants import AuthUserAttribute
-from pyvivint.constants import PubNubMessageAttribute as MessageAttributes
+from pyvivint.constants import (
+    AuthUserAttribute,
+    PubNubMessageAttribute,
+    SystemAttribute,
+    UserAttribute,
+)
 from pyvivint.pubnub import PN_CHANNEL, PN_SUBSCRIBE_KEY, VivintPubNubSubscribeListener
 from pyvivint.system import System
-from pyvivint.utils import add_async_job, first_or_none
+from pyvivint.utils import first_or_none
 from pyvivint.vivintskyapi import VivintSkyApi
 
 _LOGGER = logging.getLogger(__name__)
@@ -30,9 +34,16 @@ class Vivint:
         password: str,
         client_session: Optional[aiohttp.ClientSession] = None,
     ):
-        self.__pubnub: pubnub.pubnub_asyncio.PubNubAsyncio = None
+        self.__connected = False
+        self.__pubnub: PubNubAsyncio = None
+        self.__pubnub_listener: VivintPubNubSubscribeListener = None
         self.vivintskyapi = VivintSkyApi(username, password, client_session)
         self.systems: List[pyvivint.system.System] = []
+
+    @property
+    def connected(self):
+        """Return True if connected."""
+        return self.__connected
 
     async def connect(
         self,
@@ -55,32 +66,53 @@ class Vivint:
             _LOGGER.debug("subscribing to pubnub for realtime updates")
             await self.subscribe_for_realtime_updates(authuser_data)
 
+        self.__connected = True
+
     async def disconnect(self) -> None:
         _LOGGER.debug("disconnecting from vivintsky")
-        await self.vivintskyapi.disconnect()
+        if self.connected:
+            if self.__pubnub:
+                self.__pubnub.remove_listener(self.__pubnub_listener)
+                self.__pubnub.unsubscribe_all()
+                self.__pubnub.stop()
+            await self.vivintskyapi.disconnect()
+        self.__connected = False
 
     async def refresh(self, authuser_data: dict = None) -> None:
         # make a call to vivint's authuser endpoint to get a list of all the system_accounts (locations) & panels if not supplied
         if not authuser_data:
-            authuser_data = await self.vivintskyapi.get_authuser_data()
+            try:
+                authuser_data = await self.vivintskyapi.get_authuser_data()
+            except ClientConnectionError:
+                _LOGGER.error("Unable to refresh system(s).")
 
-        # for each system_account, make another call to load all the devices
-        for system_data in authuser_data["u"]["system"]:
-            # is this an existing account_system?
-            system = first_or_none(
-                self.systems, lambda system: system.id == system_data["panid"]
+        if authuser_data:
+            # for each system_account, make another call to load all the devices
+            for system_data in authuser_data[AuthUserAttribute.USERS][
+                UserAttribute.SYSTEM
+            ]:
+                # is this an existing account_system?
+                system = first_or_none(
+                    self.systems,
+                    lambda system: system.id == system_data[SystemAttribute.PANEL_ID],
+                )
+                if system:
+                    await system.refresh()
+                else:
+                    full_system_data = await self.vivintskyapi.get_system_data(
+                        system_data[SystemAttribute.PANEL_ID]
+                    )
+                    self.systems.append(
+                        System(
+                            system_data.get(SystemAttribute.SYSTEM_NICKNAME),
+                            full_system_data,
+                            self.vivintskyapi,
+                        )
+                    )
+
+            _LOGGER.debug(
+                f"Refreshed {len(authuser_data[AuthUserAttribute.USERS][UserAttribute.SYSTEM])} system(s)."
             )
-            if system:
-                await system.refresh()
-            else:
-                full_system_data = await self.vivintskyapi.get_system_data(
-                    system_data["panid"]
-                )
-                self.systems.append(
-                    System(system_data.get("sn"), full_system_data, self.vivintskyapi)
-                )
-
-        _LOGGER.debug(f"loaded {len(self.systems)} system(s)")
 
     async def subscribe_for_realtime_updates(self, authuser_data: dict = None) -> None:
         """Subscribes to PubNub for realtime updates."""
@@ -97,25 +129,24 @@ class Vivint:
         pnconfig.heartbeat_notification_options = PNHeartbeatNotificationOptions.ALL
 
         self.__pubnub = PubNubAsyncio(pnconfig)
-        self.__pubnub.add_listener(
-            VivintPubNubSubscribeListener(self.handle_pubnub_message)
+        self.__pubnub_listener = VivintPubNubSubscribeListener(
+            self.handle_pubnub_message
         )
+        self.__pubnub.add_listener(self.__pubnub_listener)
 
-        pn_channel = f"{PN_CHANNEL}#{authuser_data[AuthUserAttribute.USERS][AuthUserAttribute.UserAttribute.MESSAGE_BROADCAST_CHANNEL]}"
+        pn_channel = f"{PN_CHANNEL}#{authuser_data[AuthUserAttribute.USERS][UserAttribute.MESSAGE_BROADCAST_CHANNEL]}"
         self.__pubnub.subscribe().channels(pn_channel).with_presence().execute()
 
     def handle_pubnub_message(self, message: dict) -> None:
         """Handles a pubnub message."""
-        _LOGGER.info(f"message: {json.dumps(message)}")
-
-        panel_id = message.get(MessageAttributes.PANEL_ID)
+        panel_id = message.get(PubNubMessageAttribute.PANEL_ID)
         if not panel_id:
-            _LOGGER.info("ignoring pubnub message. No panel_id specified")
+            _LOGGER.info("No panel id specified - ignoring pubnub message.")
             return
 
         system = first_or_none(self.systems, lambda system: system.id == panel_id)
         if not system:
-            _LOGGER.info(f"no system found with id {panel_id}")
+            _LOGGER.info(f"No system found with id {panel_id}.")
             return
 
         system.handle_pubnub_message(message)

--- a/pyvivint/vivint.py
+++ b/pyvivint/vivint.py
@@ -1,5 +1,4 @@
 """Module that implements the Vivint class."""
-import asyncio
 import logging
 from typing import List, Optional
 
@@ -126,7 +125,9 @@ class Vivint:
         pnconfig.subscribe_key = PN_SUBSCRIBE_KEY
         pnconfig.ssl = True
         pnconfig.reconnect_policy = PNReconnectionPolicy.LINEAR
-        pnconfig.heartbeat_notification_options = PNHeartbeatNotificationOptions.ALL
+        pnconfig.heartbeat_notification_options = (
+            PNHeartbeatNotificationOptions.FAILURES
+        )
 
         self.__pubnub = PubNubAsyncio(pnconfig)
         self.__pubnub_listener = VivintPubNubSubscribeListener(

--- a/pyvivint/vivintskyapi.py
+++ b/pyvivint/vivintskyapi.py
@@ -280,6 +280,9 @@ class VivintSkyApi:
         if path != "login" and not self.is_session_valid():
             await self.connect()
 
+        if self.__client_session.closed:
+            raise VivintSkyApiError("The client session has been closed.")
+
         return await method(
             f"{VIVINT_API_ENDPOINT}/{path}",
             headers=headers,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import find_packages, setup
 
-install_requires = ["aiohttp>=3.6", "certifi>=2019.9.11", "pubnub>=5.0.0"]
+install_requires = ["aiohttp>=3.6", "certifi>=2019.9.11", "pubnub>=5.0.1"]
 
 setup(
     name="pyvivint",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import find_packages, setup
 
-install_requires = ["aiohttp>=3.6", "certifi>=2019.9.11"]
+install_requires = ["aiohttp>=3.6", "certifi>=2019.9.11", "pubnub>=5.0.0"]
 
 setup(
     name="pyvivint",


### PR DESCRIPTION
This upgrades pubnub to 5.0.1 as well as patches the logic to actually handle reconnects with pubnub_asyncio. I have two pull requests open on pubub (https://github.com/pubnub/python/pulls) to get these in to their next release. I'm not sure what they'll do with them though.

There are also some small changes to constants to get rid of more hardcoded values in the rest of the python files.

Theoretically this resolves https://github.com/ovirs/pyvivint/issues/9

Please try this one out and let me know if you see any issues!